### PR TITLE
Manual docker deploy

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -25,8 +25,8 @@ RUN echo "deb http://http.debian.net/debian buster main" > /etc/apt/sources.list
 
 # # only packages related to dev, project dependencies will get resolved via pip and setup.py
 RUN python3 -m pip install --upgrade pip 
-RUN pip install matplotlib pytest mypy types-setuptools sphinx build wheel twine click flask flask_restful flask_cors
-
+RUN pip install matplotlib pytest mypy types-setuptools sphinx build wheel twine \
+                click flask flask_restful flask_cors pandas numpy requests
 #RUN pip install -e .  # devcontainer.json: "postCreateCommand": "pip install -e .",
 
 ARG USERNAME=vscode

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -19,7 +19,7 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
+  version: 3.8
   install:
     - method: pip
       path: .

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Documentation Status](https://readthedocs.org/projects/pymzqc/badge/?version=latest)](https://pymzqc.readthedocs.io/en/latest/?badge=latest)
 [![Docker Repository on Quay](https://img.shields.io/badge/container-ready-brightgreen.svg "Docker Repository on Quay")](https://quay.io/repository/mwalzer/pymzqc?tab=tags)
 [![PyPi version](https://badgen.net/pypi/v/pymzqc/)](https://pypi.com/project/pymzqc)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/MS-Quality-hub/pymzqc/blob/main/jupyter/mzqc_in_5/write_in_5_minutes.ipynb)
 
 A python library to create and use mzQC files. Specifically, the library facilitates access to 
 mzQC files in form of a **directly usable object representation of mzQC** and offers additional 

--- a/accessories/heroku/Dockerfile.flask
+++ b/accessories/heroku/Dockerfile.flask
@@ -1,0 +1,20 @@
+FROM python:3.8-slim-buster
+
+ENV DEBIAN_FRONTEND noninteractive 
+ 
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+
+COPY requirements.txt mzqc-validator/
+RUN python -m pip install --upgrade pip
+RUN pip install -r mzqc-validator/requirements.txt
+
+# copy later, to avoid recompilation every time we change the py 
+COPY mzqc_online_validator.py mzqc-validator/
+#COPY Procfile mzqc-validator/
+
+EXPOSE 5000
+
+WORKDIR mzqc-validator/
+ENTRYPOINT [ "python" ]
+CMD [ "mzqc_online_validator.py" ]

--- a/accessories/heroku/README.md
+++ b/accessories/heroku/README.md
@@ -31,3 +31,10 @@ rsync -aP --delete /home/walzer/psi/pymzqc/acessories/heroku  /tmp/mzqc-validato
 git push heroku master
 ```
 
+### Creating a custom, standalone Docker container
+
+```
+docker build . --file Dockerfile.flask -t mzqc-validator
+docker run --rm -p5000:5000 mzqc-validator
+```
+

--- a/accessories/heroku/mzqc_online_validator.py
+++ b/accessories/heroku/mzqc_online_validator.py
@@ -106,4 +106,4 @@ api.add_resource(Documentation, '/documentation/')
 api.add_resource(Validator, '/validator/')
 
 if __name__ == '__main__':
-    app.run()
+    app.run(host = '0.0.0.0')

--- a/tests/test_online_validator.py
+++ b/tests/test_online_validator.py
@@ -1,0 +1,19 @@
+from mzqc import MZQCFile as qc
+import json
+import requests
+
+url = "https://apps.lifs-tools.org/mzqcvalidator/validator/"
+# payload={
+#     "data1":1234,'data2':'test'
+# }
+with open("tests/nameOfYourFile.mzQC", "r") as file:
+    payload = qc.JsonSerialisable.from_json(file)
+            
+headers = {'Content-Type': 'text/plain'}
+response = requests.post(url, headers=headers, data=qc.JsonSerialisable.to_json(payload))
+print(response.text , response.status_code)
+
+
+headers = {'Content-Type': 'application/json'}
+response = requests.post(url, headers=headers, data=qc.JsonSerialisable.to_json(payload))
+print(response.text , response.status_code)


### PR DESCRIPTION
Added new docker file for standalone flask-based docker container.
Updated README with short instructions.

Application is currently deployed at https://apps.lifs-tools.org/mzqcvalidator/